### PR TITLE
fix: Remove duplicate openapi variable declaration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ async fn main() {
             ]),
     );
 
-    let openapi = vespera_openapi!();
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     println!("API server is running on port {}", port);
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();


### PR DESCRIPTION
Removed unused openapi variable from README.

Fixes #12